### PR TITLE
feat: Removes `content-length` header from captured responses

### DIFF
--- a/modules/strawman-cli-server/commands/capture.ts
+++ b/modules/strawman-cli-server/commands/capture.ts
@@ -80,14 +80,12 @@ const parseParametersFromCliArguments = (args: string[]): CommandParameters => {
   }
 
   return {
-    theRemoteRootUri: new URL(
-      args[1] as string,
-    ),
+    theRemoteRootUri: new URL(positional[1] as string),
     theLocalRootUri: new URL(
-      options.l ?? options["local-root-uri"] ?? "http://localhost:8080",
+      options.l ?? options["local-root-uri"] ?? "http://localhost:8080"
     ),
-    thePathToSnapshotDirectory: options.s ?? options["snapshot-dir"] ??
-      "./snapshots",
+    thePathToSnapshotDirectory:
+      options.s ?? options["snapshot-dir"] ?? "./snapshots",
   };
 };
 

--- a/modules/strawman-core/domain/model/Snapshot.spec.ts
+++ b/modules/strawman-core/domain/model/Snapshot.spec.ts
@@ -107,6 +107,22 @@ Deno.test({
 });
 
 Deno.test({
+  name: "When created from fetch response `Snapshot` removes the content-length header",
+  fn: async () => {
+    const response = new Response(JSON.stringify({ hello: "world" }), {
+      headers: {
+        "content-type": "application/json; charset=UTF-8",
+        "content-length": "17"
+      },
+    });
+    const snapshot = await Snapshot.fromFetchResponse(response);
+    const snapshotResponse = snapshot.toFetchResponse();
+
+    assert(snapshotResponse.headers.has("content-length") === false);
+  },
+});
+
+Deno.test({
   name: "`Snapshot` can be created from string",
   fn: () => {
     const snapshot = Snapshot.fromString(snapshotAsString);

--- a/modules/strawman-core/domain/model/Snapshot.ts
+++ b/modules/strawman-core/domain/model/Snapshot.ts
@@ -35,7 +35,11 @@ export class Snapshot {
     new Snapshot({
       statusCode: response.status,
       statusText: response.statusText,
-      headers: Object.fromEntries(response.headers.entries()),
+      headers: Object.fromEntries(
+        [...response.headers.entries()].filter(
+          ([key]) => key.toLowerCase() !== "content-length"
+        )
+      ),
       body: await response.clone().text(),
     });
 


### PR DESCRIPTION
Closes: #4 