### PR TITLE
feat: Adds Manifest & `init` command

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,23 @@
+/**
+ * strawman - A Deno-based service virtualization solution
+ * Copyright (C) 2022 Open Formation GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ */
+
+export type { Manifest } from "./modules/strawman-core/application/manifest.ts";

--- a/modules/strawman-cli/cli.ts
+++ b/modules/strawman-cli/cli.ts
@@ -24,10 +24,12 @@ import { parse } from "../../deps/flags.ts";
 
 import { VERSION } from "../../version.ts";
 
+import * as init from "./commands/init.ts";
 import * as start from "./commands/start.ts";
 import * as rc from "./commands/rc.ts";
 
 const commands = {
+  init,
   start,
   rc,
 } as const;

--- a/modules/strawman-cli/commands/init.ts
+++ b/modules/strawman-cli/commands/init.ts
@@ -1,0 +1,77 @@
+/**
+ * strawman - A Deno-based service virtualization solution
+ * Copyright (C) 2022 Open Formation GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ */
+
+import { parse } from "../../../deps/flags.ts";
+
+import { createLogger, createLogPrinter } from "../../strawman-logger/mod.ts";
+
+import { makeCreateSnapshotDirectoryIfNotExists } from "../lib/createSnapshotDirectoryIfNotExists.ts";
+import { makeCreateManifestFile } from "../lib/createManifestFile.ts";
+
+export const shortDescription = "Initialize a snapshot directory";
+
+export const helpMessage = `
+Usage:
+  strawman init
+
+Options:
+  -s, --snapshot-dir    The directory that captured snaphots should be saved 
+                        in. Strawman will attempt to create this directory if
+                        it does not exist yet. (defaults to: ./snapshots)
+
+Examples:
+  strawman init -s ./path/to/snapshots
+`;
+
+type CommandParameters = {
+  thePathToSnapshotDirectory: string;
+};
+
+export const run = async () => {
+  const parameters = parseParametersFromCliArguments(Deno.args);
+  const logger = createLogger();
+  const logPrinter = createLogPrinter();
+
+  const createSnapshotDirectoryIfNotExists =
+    makeCreateSnapshotDirectoryIfNotExists({
+      logger,
+    });
+  const createManifestFile = makeCreateManifestFile({
+    logger,
+  });
+
+  logger.subscribe(logPrinter);
+
+  await createSnapshotDirectoryIfNotExists(
+    parameters.thePathToSnapshotDirectory,
+  );
+  await createManifestFile(parameters.thePathToSnapshotDirectory);
+};
+
+const parseParametersFromCliArguments = (args: string[]): CommandParameters => {
+  const { _, ...options } = parse(args);
+
+  return {
+    thePathToSnapshotDirectory: options.s ?? options["snapshot-dir"] ??
+      "./snapshots",
+  };
+};

--- a/modules/strawman-cli/commands/start.ts
+++ b/modules/strawman-cli/commands/start.ts
@@ -26,6 +26,7 @@ import { createLogger, createLogPrinter } from "../../strawman-logger/mod.ts";
 
 import { makeModifyTemplate } from "../../strawman-core/domain/service/modifyTemplate.ts";
 
+import { makeImportManifest } from "../../strawman-core/infrastructure/fs/importManifest.ts";
 import { makeImportTemplate } from "../../strawman-core/infrastructure/fs/importTemplate.ts";
 import { makeSyncVirtualServiceTreeWithDirectory } from "../../strawman-core/infrastructure/fs/syncVirtualServiceTreeWithDirectory.ts";
 
@@ -93,11 +94,17 @@ export const run = async () => {
     makeSyncVirtualServiceTreeWithDirectory({
       pathToDirectory: parameters.thePathToSnapshotDirectory,
     });
+  const importManifest = makeImportManifest({
+    import: (pathToTemplateFile) => import(pathToTemplateFile),
+  });
   const strawman = makeStrawman({
     urlOfProxiedService: parameters.theRemoteRootUri,
     virtualServiceTree,
     subscribers: [syncVirtualServiceTreeToDirectory],
     logger,
+    manifest: await importManifest(
+      parameters.thePathToSnapshotDirectory,
+    ),
   });
 
   strawman.setMode(parameters.theMode);

--- a/modules/strawman-cli/lib/createManifestFile.ts
+++ b/modules/strawman-cli/lib/createManifestFile.ts
@@ -28,6 +28,8 @@ import { castError } from "../../framework/castError.ts";
 
 import { ILogger } from "../../strawman-logger/mod.ts";
 
+import { fileExists } from "./fileExists.ts";
+
 const manifestTemplate =
   `import type { Manifest } from "https://deno.land/x/strawman@${VERSION}/mod.ts";
 
@@ -45,8 +47,14 @@ export const makeCreateManifestFile = (
     );
 
     try {
-      await Deno.writeTextFile(pathToManifestFile, manifestTemplate);
-      deps.logger.info(`Manifest file "${pathToManifestFile}" was written`);
+      if (await fileExists(pathToManifestFile)) {
+        deps.logger.error(
+          `Manifest file "${pathToManifestFile}" already exists`,
+        );
+      } else {
+        await Deno.writeTextFile(pathToManifestFile, manifestTemplate);
+        deps.logger.info(`Manifest file "${pathToManifestFile}" was written`);
+      }
     } catch (err) {
       deps.logger.fatal(
         new Error(

--- a/modules/strawman-cli/lib/createManifestFile.ts
+++ b/modules/strawman-cli/lib/createManifestFile.ts
@@ -20,23 +20,37 @@
  * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
  */
 
+import * as path from "../../../deps/path.ts";
+
+import { VERSION } from "../../../version.ts";
+
 import { castError } from "../../framework/castError.ts";
 
 import { ILogger } from "../../strawman-logger/mod.ts";
 
-export const makeCreateSnapshotDirectoryIfNotExists = (
+const manifestTemplate =
+  `import type { Manifest } from "https://deno.land/x/strawman@${VERSION}/mod.ts";
+
+export const manifest: Manifest = {
+};
+`;
+
+export const makeCreateManifestFile = (
   deps: { logger: ILogger },
 ) => {
-  const createSnapshotDirectoryIfNotExists = async (
-    pathToSnapshotDirectory: string,
-  ) => {
+  const createManifestFile = async (pathToSnapshotDirectory: string) => {
+    const pathToManifestFile = path.join(
+      pathToSnapshotDirectory,
+      "manifest.ts",
+    );
+
     try {
-      await Deno.mkdir(pathToSnapshotDirectory, { recursive: true });
-      deps.logger.info(`Directory "${pathToSnapshotDirectory}" was created`);
+      await Deno.writeTextFile(pathToManifestFile, manifestTemplate);
+      deps.logger.info(`Manifest file "${pathToManifestFile}" was written`);
     } catch (err) {
       deps.logger.fatal(
         new Error(
-          `Directory "${pathToSnapshotDirectory}" could not be created`,
+          `Manifest file "${pathToManifestFile}" could not be written`,
           { cause: castError(err) },
         ),
       );
@@ -44,5 +58,5 @@ export const makeCreateSnapshotDirectoryIfNotExists = (
     }
   };
 
-  return createSnapshotDirectoryIfNotExists;
+  return createManifestFile;
 };

--- a/modules/strawman-cli/lib/createSnapshotDirectoryIfNotExists.ts
+++ b/modules/strawman-cli/lib/createSnapshotDirectoryIfNotExists.ts
@@ -24,6 +24,8 @@ import { castError } from "../../framework/castError.ts";
 
 import { ILogger } from "../../strawman-logger/mod.ts";
 
+import { fileExists } from "./fileExists.ts";
+
 export const makeCreateSnapshotDirectoryIfNotExists = (
   deps: { logger: ILogger },
 ) => {
@@ -31,8 +33,14 @@ export const makeCreateSnapshotDirectoryIfNotExists = (
     pathToSnapshotDirectory: string,
   ) => {
     try {
-      await Deno.mkdir(pathToSnapshotDirectory, { recursive: true });
-      deps.logger.info(`Directory "${pathToSnapshotDirectory}" was created`);
+      if (await fileExists(pathToSnapshotDirectory)) {
+        deps.logger.debug(
+          `Directory "${pathToSnapshotDirectory}" exists and won't be created`,
+        );
+      } else {
+        await Deno.mkdir(pathToSnapshotDirectory, { recursive: true });
+        deps.logger.info(`Directory "${pathToSnapshotDirectory}" was created`);
+      }
     } catch (err) {
       deps.logger.fatal(
         new Error(

--- a/modules/strawman-cli/lib/fileExists.ts
+++ b/modules/strawman-cli/lib/fileExists.ts
@@ -1,0 +1,36 @@
+/**
+ * strawman - A Deno-based service virtualization solution
+ * Copyright (C) 2022 Open Formation GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ */
+
+import * as path from "../../../deps/path.ts";
+
+export const fileExists = async (pathToFile: string): Promise<boolean> => {
+  const dirname = path.dirname(pathToFile);
+  const basename = path.basename(pathToFile);
+
+  for await (const file of Deno.readDir(dirname)) {
+    if (file.name === basename) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/modules/strawman-core/application/manifest.ts
+++ b/modules/strawman-core/application/manifest.ts
@@ -1,0 +1,26 @@
+/**
+ * strawman - A Deno-based service virtualization solution
+ * Copyright (C) 2022 Open Formation GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ */
+
+export type Manifest = {
+  readonly middlewares?:
+    ((request: Request, next: () => Promise<Response>) => Promise<Response>)[];
+};

--- a/modules/strawman-core/infrastructure/fs/importManifest.ts
+++ b/modules/strawman-core/infrastructure/fs/importManifest.ts
@@ -1,0 +1,61 @@
+/**
+ * strawman - A Deno-based service virtualization solution
+ * Copyright (C) 2022 Open Formation GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Wilhelm Behncke <wilhelm.behncke@openformation.io>
+ */
+
+import * as path from "../../../../deps/path.ts";
+
+import { Exception } from "../../../framework/exception.ts";
+
+import type { Manifest } from "../../application/manifest.ts";
+
+import { fileUrlFromPath } from "./fileUrlFromPath.ts";
+
+export type IImportManifest = ReturnType<typeof makeImportManifest>;
+
+export const makeImportManifest = (deps: {
+  import: (pathToScriptFile: string) => Promise<{ default: unknown }>;
+}) => {
+  const importManifest = async (pathToDirectory: string) => {
+    const pathToManifestFile = path.join(pathToDirectory, "manifest.ts");
+    let manifest: Manifest;
+
+    try {
+      const module = await deps.import(
+        fileUrlFromPath(pathToManifestFile),
+      ) as unknown as { manifest: Manifest };
+
+      manifest = module.manifest;
+    } catch {
+      return {};
+    }
+
+    if (typeof manifest === "undefined") {
+      throw Exception.raise({
+        code: 1649601233,
+        message: `Expected "${pathToManifestFile}" to export a manifest.`,
+      });
+    }
+
+    return manifest;
+  };
+
+  return importManifest;
+};


### PR DESCRIPTION
Closes: #8 
Closes: #18 

---

## How to test

Since we do not have an install script yet (see: #22), it's best to set up an alias for strawman first:
```bash
alias strawman="deno run --unstable --allow-read --allow-write --allow-net modules/strawman-cli/cli.ts"
```

### `strawman init`

The `strawman init` command creates a snapshot directory with a blank manifest file.

You can just run:
```sh
strawman init
```

...which will create the snapshot directory at `./snapshots`. To customize the directory, you can run:

```sh
strawman init -s /some/other/path
```

You should see the this output:
```
███████╗████████╗██████╗  █████╗ ██╗    ██╗███╗   ███╗ █████╗ ███╗   ██╗
██╔════╝╚══██╔══╝██╔══██╗██╔══██╗██║    ██║████╗ ████║██╔══██╗████╗  ██║
███████╗   ██║   ██████╔╝███████║██║ █╗ ██║██╔████╔██║███████║██╔██╗ ██║
╚════██║   ██║   ██╔══██╗██╔══██║██║███╗██║██║╚██╔╝██║██╔══██║██║╚██╗██║
███████║   ██║   ██║  ██║██║  ██║╚███╔███╔╝██║ ╚═╝ ██║██║  ██║██║ ╚████║
╚══════╝   ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝

Strawman Server 1.0.0-alpha.1

[⚐] Directory "./snapshots" was created
[⚐] Manifest file "snapshots/manifest.ts" was written
```

If the command was successful, the snapshot directory and a manifest file should have been created. The manifest file should look like this:

```typescript
import type { Manifest } from "https://deno.land/x/strawman@1.0.0-alpha.1/mod.ts";

export const manifest: Manifest = {
};
```

**Hint:** Running the `strawman init` command on an existing setup should lead to an error.

### Manifest & Middlewares

To test the new middleware functionality, you need to adjust the manifest file that has just been created. 

Long story short, the following should be a suitable test setup:

```typescript
import type { Manifest } from "../mod.ts"; // The import path needs to be adjusted, since the manifest type hasn't been published yet.

export const manifest: Manifest = {
  middlewares: [
    (request, next) => {
      if (new URL(request.url).pathname === "/") {
        return Promise.resolve(
          new Response("Hello from Middleware", {
            status: 200,
            statusText: "OK",
          }),
        );
      }

      return next();
    },
  ],
};
```

Now you can start a strawman server in replay mode (the remote service URI doesn't matter here, since the middleware will interrupt request handling for good):
```sh
strawman start -e -m replay https://httpbin.org
```

If you now send a request to the strawman server:
```
curl http://localhost:8080/
```

You should receive the following response:
```
Hello from Middleware
```

A middleware function has the following signature:
```typescript
(request: Request, next: () => Promise<Response>) => Promise<Response>
```

Calling `next` calls the next middleware function in the chain (or the final request handler at the end of the chain).